### PR TITLE
Fix Email Approval Purchasing Service

### DIFF
--- a/packages/point/point-purchasing/src/views/emails/purchasing/point/approval/service-invoice.blade.php
+++ b/packages/point/point-purchasing/src/views/emails/purchasing/point/approval/service-invoice.blade.php
@@ -181,20 +181,37 @@
         </table>
 
         <table cellpadding="0" cellspacing="0">
-            <tr class="heading">
-                <td>Service</td>
-                <td>Notes</td>
-                <td>Allocation</td>
-                <td style="text-align: right;">QTY</td>
-                <td style="text-align: right;">Price</td>
-                <td style="text-align: right;">Disc (%)</td>
-                <td style="text-align: right;">Subtotal</td>
-            </tr>
-
-            <?php 
+            <?php
+                $column_discount = false;
+                foreach($invoice->services as $service) {
+                    if($service->discount > 0) {
+                        $column_discount = true;
+                        break;
+                    }
+                }
+                if(!$column_discount) {
+                    foreach ($invoice->items as $item) {
+                        if($item->discount > 0) {
+                            $column_discount = true;
+                            break;
+                        }
+                    }
+                }
                 $total_service = 0;
                 $total_item = 0;
+                $colspan_needed = $column_discount ? 4 : 3;
             ?>
+            <tr class="heading">
+                <td>Service</td>
+                <td>Allocation</td>
+                <td style="text-align: right;">Price</td>
+
+                @if($column_discount)
+                    <td style="text-align: right;">Disc (%)</td>
+                @endif
+                
+                <td style="text-align: right;">Subtotal</td>
+            </tr>
             
             @foreach($invoice->services as $service)
                 <?php
@@ -205,32 +222,25 @@
                 <tr class="item">
                     <td>
                         {{ ucfirst($service->service->name) }}
-                    </td>
-                    <td>
+                        (QTY : {{ number_format_quantity($service->quantity) }})
+                        <br>
                         {{ ucfirst($service->service_notes) }}
                     </td>
-                    <td>
-                        {{ ucwords($service->allocation->name) }}
-                    </td>
-                    <td style="text-align: right;">
-                        {{ number_format_quantity($service->quantity) }}
-                    </td>
-                    <td style="text-align: right; ">
-                        {{ number_format_quantity($service->price) }}
-                    </td>
-                    <td style="text-align: right;">
-                        {{ number_format_quantity($service->discount) }}
-                    </td>
-                    <td style="text-align: right;">
-                        {{ number_format_quantity($subtotal) }}
-                    </td>
+                    <td>{{ ucwords($service->allocation->name) }}</td>
+                    <td style="text-align: right;">{{ number_format_quantity($service->price) }}</td>
+                    
+                    @if($column_discount)
+                        <td style="text-align: right;">{{ number_format_quantity($service->discount) }}</td>
+                    @endif
+
+                    <td style="text-align: right;">{{ number_format_quantity($subtotal) }}</td>
                 </tr>
             @endforeach
 
             @if(count($invoice->items) > 0)
                 <tr class="heading">
-                    <td style="text-align: right;" colspan="6">
-                        TOTAL SERVICE
+                    <td style="text-align: right;" colspan="{{$colspan_needed}}">
+                        Total Service
                     </td>
                     <td style="text-align: right;">
                         {{ number_format_quantity($total_service) }}
@@ -239,11 +249,13 @@
 
                 <tr class="heading">
                     <td>Item</td>
-                    <td>Notes</td>
                     <td>Allocation</td>
-                    <td style="text-align: right;">QTY</td>
                     <td style="text-align: right;">Price</td>
-                    <td style="text-align: right;">Disc (%)</td>
+
+                    @if($column_discount)
+                        <td style="text-align: right;">Disc (%)</td>
+                    @endif
+                    
                     <td style="text-align: right;">Subtotal</td>
                 </tr>
 
@@ -256,31 +268,24 @@
                     <tr class="item">
                         <td>
                             {{ ucfirst($item->item->name) }}
-                        </td>
-                        <td>
+                            (QTY : {{ number_format_quantity($item->quantity) }})
+                            <br>
                             {{ ucfirst($item->item_notes) }}
                         </td>
-                        <td>
-                            {{ ucwords($item->allocation->name) }}
-                        </td>
-                        <td style="text-align: right;">
-                            {{ number_format_quantity($item->quantity) }}
-                        </td>
-                        <td style="text-align: right; ">
-                            {{ number_format_quantity($item->price) }}
-                        </td>
-                        <td style="text-align: right;">
-                            {{ number_format_quantity($item->discount) }}
-                        </td>
-                        <td style="text-align: right;">
-                            {{ number_format_quantity($subtotal) }}
-                        </td>
+                        <td>{{ ucwords($item->allocation->name) }}</td>
+                        <td style="text-align: right;">{{ number_format_quantity($item->price) }}</td>
+
+                        @if($column_discount)
+                            <td style="text-align: right;">{{ number_format_quantity($item->discount) }}</td>
+                        @endif
+                        
+                        <td style="text-align: right;">{{ number_format_quantity($subtotal) }}</td>
                     </tr>
                 @endforeach
 
                 <tr class="heading">
-                    <td style="text-align: right;" colspan="6">
-                        TOTAL ITEMS
+                    <td style="text-align: right;" colspan="{{$colspan_needed}}">
+                        Total Item
                     </td>
                     <td style="text-align: right;">
                         {{ number_format_quantity($total_item) }}
@@ -288,10 +293,10 @@
                 </tr>
             @endif
 
-            @if($invoice->discount > 0 || ($invoice->tax > 0 && $invoice->type_of_tax == "include"))
+            @if($invoice->discount > 0 || $invoice->tax > 0)
                 <tr class="heading">
-                    <td style="text-align: right;" colspan="6">
-                        SUBTOTAL
+                    <td style="text-align: right;" colspan="{{$colspan_needed}}">
+                        Subtotal
                     </td>
                     <td style="text-align: right;">
                         {{ number_format_quantity($invoice->subtotal) }}
@@ -301,8 +306,8 @@
 
             @if($invoice->discount > 0)
                 <tr class="heading">
-                    <td style="text-align: right;" colspan="6">
-                        DISCOUNT
+                    <td style="text-align: right;" colspan="{{$colspan_needed}}">
+                        Discount
                     </td>
                     <td style="text-align: right;">
                         {{ number_format_quantity($invoice->discount) }}
@@ -311,17 +316,20 @@
             @endif
 
             @if($invoice->tax > 0)
+                @if($invoice->type_of_tax == "include")
+                    <tr class="heading">
+                        <td style="text-align: right;" colspan="{{$colspan_needed}}">
+                            Tax Base
+                        </td>
+                        <td style="text-align: right;">
+                            {{ number_format_quantity($invoice->tax_base) }}
+                        </td>
+                    </tr>
+                @endif
+                
                 <tr class="heading">
-                    <td style="text-align: right;" colspan="6">
-                        TAX BASE
-                    </td>
-                    <td style="text-align: right;">
-                        {{ number_format_quantity($invoice->tax_base) }}
-                    </td>
-                </tr>
-                <tr class="heading">
-                    <td style="text-align: right;" colspan="6">
-                        TAX
+                    <td style="text-align: right;" colspan="{{$colspan_needed}}">
+                        Tax
                     </td>
                     <td style="text-align: right;">
                         {{ number_format_quantity($invoice->tax) }}
@@ -330,8 +338,8 @@
             @endif
 
             <tr class="heading">
-                <td style="text-align: right;" colspan="6">
-                    TOTAL INVOICE
+                <td style="text-align: right;" colspan="{{$colspan_needed}}">
+                    Total Invoice
                 </td>
                 <td style="text-align: right;">
                     {{ number_format_quantity($invoice->total) }}

--- a/packages/point/point-purchasing/src/views/emails/purchasing/point/approval/service-payment-order.blade.php
+++ b/packages/point/point-purchasing/src/views/emails/purchasing/point/approval/service-payment-order.blade.php
@@ -33,10 +33,6 @@
             
         }
 
-        .invoice-box table tr td:nth-child(2) {
-            text-align: right;
-        }
-
         .invoice-box table tr.top table td {
             padding-bottom: 20px;
         }
@@ -130,16 +126,12 @@
 <div class="invoice-box">
     Hi, you have an request approval purchase payment order from {{ $username }}. We would like to inform the
     details as follows :
+    
+    <?php
+        $total_all_payment_order = 0;
+    ?>
 
    @foreach($list_data as $payment_order)
-        <?php
-            $payment_order = \Point\PointPurchasing\Models\Service\PaymentOrder::find($payment_order['id']);
-            $total = 0;
-            $total_remaining = 0;
-            $total_payment = 0;
-            $row = 0;
-        ?>
-
         <table cellpadding="0" cellspacing="0" style="padding: 20px 0;">
             <tr>
                 <td style="width: 20%;">
@@ -149,7 +141,9 @@
                     :
                 </td>
                 <td>
-                    {{ $payment_order->formulir->form_number }}</a>
+                    <a href="{{ url('purchasing/point/service/payment-order/'.$payment_order->id) }}">
+                        {{ $payment_order->formulir->form_number }}
+                    </a>
                 </td>
             </tr>
             <tr>
@@ -160,7 +154,7 @@
                     :
                 </td>
                 <td>
-                    {{ \DateHelper::formatView($payment_order->formulir->form_date) }}
+                    {{ \DateHelper::formatView($payment_order->formulir->form_date, true) }}
                 </td>
             </tr>
             <tr>
@@ -171,240 +165,188 @@
                     :
                 </td>
                 <td>
-                    {{ $payment_order->person->codeName }}
+                    {!! get_url_person($payment_order->person_id) !!}
+                </td>
+            </tr>
+            <tr>
+                <td style="width: 20%;">
+                    Notes
+                </td>
+                <td>
+                    :
+                </td>
+                <td>
+                    {{ ucfirst($payment_order->notes) }}
                 </td>
             </tr>
         </table>
+
+        <?php
+            $total_payment_order = 0;
+        ?>
 
         <table cellpadding="0" cellspacing="0">
             @foreach($payment_order->details as $payment_order_detail)
                 <?php
                     $model = $payment_order_detail->reference->formulirable_type;
                     $reference = $model::find($payment_order_detail->reference->formulirable_id);
-                    $subtotal = $reference->tax_base;
-                    $tax = $reference->tax;
-                    $total_invoice = $subtotal+$tax;
-                    $total += $total_invoice;
-                    $row++;
                 ?>
-
                 @if (get_class($reference) == 'Point\PointPurchasing\Models\Service\Invoice')
+                    <?php
+                        $invoice = $reference;
+                        $total_payment_order += $payment_order_detail->amount;
+                        $total_all_payment_order += $total_payment_order;
+
+                        $invoice_remaining = \Point\Framework\Helpers\ReferHelper::remaining(get_class($invoice), $invoice->id, $invoice->total);
+                    ?>
+
                     <tr class="heading">
-                        <td colspan="5">INVOICE: {{ $reference->formulir->form_number }}</td>
-                    </tr>
-                    <tr class="heading">
-                        <td>
-                            Notes
-                        </td>
-                        <td style="text-align: right;">
-                            Invoice Amount
-                        </td>
-                        <td style="text-align: right;">
-                            Remaining Amount
-                        </td>
-                        <td style="text-align: right;">
-                            Total Payment
-                        </td>
-                        <td>
-                            Allocation
+                        <td colspan="6">
+                            INVOICE :
+                            <a href="{{url('purchasing/point/service/invoice/'.$invoice->formulir_id)}}">
+                                {{ $invoice->formulir->form_number }}
+                            </a>
                         </td>
                     </tr>
-                    @foreach($reference->services as $invoice_service)
+                        
+                    <tr class="heading">
+                        <td>Service & Item</td>
+                        <td>Allocation</td>
+                        <td style="text-align: right;">Price</td>
+                        <td style="text-align: right;">Disc (%)</td>
+                        <td style="text-align: right;">Subtotal</td>
+                        <td style="text-align: right;">Payment</td>
+                    </tr>
+                    
+                    @foreach($invoice->services as $service)
                         <?php
-                            $total_remaining += \Point\Framework\Helpers\ReferHelper::remaining(get_class($reference), $reference->id, $reference->total) + $payment_order_detail->amount;
+                            $subtotal = ($service->quantity * $service->price);
+                            $subtotal -= ($service->quantity * $service->price * $service->discount / 100);
                         ?>
                         <tr class="item">
                             <td>
-                                {{$invoice_service->service->name}} (Qty: {{number_format_quantity($invoice_service->quantity)}})
+                                {{ ucfirst($service->service->name) }}
+                                (QTY: {{ number_format_quantity($service->quantity) }})
+                                <br>
+                                {{ ucfirst($service->service_notes) }}
                             </td>
-                            <td style="text-align: right;">
-                                {{number_format_quantity($invoice_service->price * $invoice_service->quantity - ($invoice_service->price * $invoice_service->quantity * $invoice_service->discount / 100))}}
-                            </td>
-                            <td style="text-align: right;">
-                                {{number_format_quantity(\Point\Framework\Helpers\ReferHelper::remaining(get_class($reference), $reference->id, $reference->total) + $payment_order_detail->amount)}}
-                            </td>
-                            <td style="text-align: right;">
-                                {{number_format_quantity($payment_order_detail->amount)}}
-                            </td>
-                            <td>
-                                {{$invoice_service->allocation->name}}
-                            </td>
+                            <td>{{ ucwords($service->allocation->name) }}</td>
+                            <td style="text-align: right; ">{{ number_format_quantity($service->price) }}</td>
+                            <td style="text-align: right;">{{ number_format_quantity($service->discount) }}</td>
+                            <td style="text-align: right;">{{ number_format_quantity($subtotal) }}</td>
+                            <td></td>
                         </tr>
                     @endforeach
-                    @foreach($reference->items as $item)
+
+                    @foreach($invoice->items as $item)
+                        <?php
+                            $subtotal = ($item->quantity * $item->price);
+                            $subtotal -= ($item->quantity * $item->price * $item->discount / 100);
+                        ?>
                         <tr class="item">
                             <td>
-                                {{$item->item->name}}({{$item->item_notes}}) (Qty: {{$item->quantity}})
+                                {{ ucfirst($item->item->name) }}
+                                (QTY : {{ number_format_quantity($item->quantity) }})
+                                <br>
+                                {{ ucfirst($item->item_notes) }}
                             </td>
-                            <td style="text-align: right;">
-                                {{number_format_quantity($item->price * $item->quantity - ($item->price * $item->quantity * $item->discount / 100))}}
-                            </td>
+                            <td>{{ ucwords($item->allocation->name) }}</td>
+                            <td style="text-align: right;">{{ number_format_quantity($item->price) }}</td>
+                            <td style="text-align: right;">{{ number_format_quantity($item->discount) }}</td>
+                            <td style="text-align: right;">{{ number_format_quantity($subtotal) }}</td>
                             <td></td>
-                            <td></td>
-                            <td>
-                                {{$item->allocation->name}}
-                            </td>
                         </tr>
                     @endforeach
-                    @if($tax > 0)
+
                     <tr class="heading">
-                        <td style="text-align: right; font-weight: normal;">
-                            SUBTOTAL
+                        <td style="text-align: right;" colspan="4">
+                            Invoice Subtotal
                         </td>
-                        <td style="text-align: right; font-weight: normal;">
-                            {{number_format_quantity($subtotal)}}
+                        <td style="text-align: right;">
+                            {{ number_format_quantity($invoice->subtotal) }}
                         </td>
-                        <td></td>
-                        <td></td>
                         <td></td>
                     </tr>
-                    <tr class="heading">
-                        <td style="text-align: right; font-weight: normal;">
-                            GST
-                        </td>
-                        <td style="text-align: right; font-weight: normal;">
-                            {{number_format_quantity($tax)}}
-                        </td>
-                        <td></td>
-                        <td></td>
-                        <td></td>
-                    </tr>
+
+                    @if($invoice->discount > 0)
+                        <tr class="heading">
+                            <td style="text-align: right;" colspan="4">
+                                Invoice Discount
+                            </td>
+                            <td style="text-align: right;">
+                                {{ number_format_quantity($invoice->discount) }}
+                            </td>
+                            <td></td>
+                        </tr>
                     @endif
+
+                    @if($invoice->tax > 0)
+                        <tr class="heading">
+                            <td style="text-align: right;" colspan="4">
+                                Tax ({{ ucfirst($invoice->type_of_tax) }})
+                            </td>
+                            <td style="text-align: right;">
+                                {{ number_format_quantity($invoice->tax) }}
+                            </td>
+                            <td></td>
+                        </tr>
+                    @endif
+
                     <tr class="heading">
-                        <td style="text-align: right;" colspan="3">
-                            TOTAL PAYMENT
+                        <td style="text-align: right;" colspan="4">
+                            Invoice Total
                         </td>
                         <td style="text-align: right;">
-                            {{number_format_quantity($payment_order_detail->amount)}}
+                            {{ number_format_quantity($invoice->total) }}
+                        </td>
+                        <td style="text-align: right;">
+                            {{ number_format_quantity($payment_order_detail->amount) }}
+                        </td>
+                    </tr>
+
+                    <tr class="heading">
+                        <td style="text-align: right;" colspan="4">
+                            Invoice Remaining
+                        </td>
+                        <td style="text-align: right;">
+                            {{ number_format_quantity($invoice_remaining) }}
                         </td>
                         <td></td>
+                    </tr>
+                @elseif(get_class($reference) == "Point\PointPurchasing\Models\Service\Downpayment")
+                    <tr class="heading">
+                        <td style="text-align: right;" colspan="5">
+                            Downpayment
+                            <a href="{{url('purchasing/point/service/downpayment/'.$reference->formulir_id)}}">
+                                {{ $reference->formulir->form_number }}
+                            </a>
+                        </td>
+                        <td style="text-align: right;">
+                            -{{ number_format_quantity($reference->amount)}}
+                        </td>
                     </tr>
                 @endif
             @endforeach
-
-            <tr><td colspan="6"></td></tr>
-
-            @if(count($payment_order->others) > 0)
-                <?php
-                    $total_invoice = 0;
-                    $row++;
-                ?>
-                <tr class="heading">
-                    <td>
-                        Notes
-                    </td>
-                    <td></td>
-                    <td></td>
-                    <td style="text-align: right;">
-                        Total Payment
-                    </td>
-                    <td>
-                        Allocation
-                    </td>
-                </tr>
-
-                @foreach($payment_order->others as $payment_order_other)
-                    <?php
-                        $row++;
-                    ?>
-                    <tr class="item">
-                        <td>
-                            {{ $payment_order_other->coa->account }} {{$payment_order_other->other_notes}}
-                        </td>
-                        <td></td>
-                        <td></td>
-                        <td style="text-align: right;">
-                            {{number_format_quantity($payment_order_other->amount)}}
-                        </td>
-                        <td>
-                            {{$payment_order_other->allocation->name}}
-                        </td>
-                    </tr>
-                    <?php $total_invoice += $payment_order_other->amount; ?>
-                @endforeach
-
-                <tr class="heading">
-                    <td style="text-align: right;" colspan="2">
-                        TOTAL
-                    </td>
-                    <td></td>
-                    <td style="text-align: right;">
-                        {{number_format_quantity($total_invoice)}}
-                    </td>
-                    <td></td>
-                </tr>
-
-                <?php
-                    $total += $total_invoice;
-                ?>
-            @endif
-
-
-            <tr><td colspan="6"></td></tr>
-
-            
-            <tr class="heading">
-                <td style="text-align: right; font-weight: normal;" colspan="3">
-                    <b>TOTAL PAYMENT</b>
-                </td>
-                <td style="text-align: right; font-weight: normal;">
-                    {{number_format_quantity($payment_order->total_payment)}}
-                </td>
-                <td></td>
-            </tr>
-
-            <?php $is_dp = 0; ?>
-            @foreach($payment_order->details as $payment_order_detail)
-                @if($payment_order_detail->reference->formulirable_type == "Point\\PointPurchasing\\Models\\Service\\Downpayment")
-                    <tr class="heading">
-                        <td style="text-align: right; font-weight: normal;" colspan="2">
-                            DOWN PAYMENT
-                        </td>
-                        <td style="text-align: right; font-weight: normal;">
-                            {{number_format_quantity($payment_order_detail->amount)}}
-                        </td>
-                        <td></td>
-                    </tr>
-                    <?php $is_dp = 1; ?>
-                @endif
-            @endforeach
-
-            @if ($is_dp)
-            <tr class="heading">
-                <td style="text-align: right;">
-                    TOTAL PAYMENT
-                </td>
-                <td></td>
-                <td></td>
-                <td style="text-align: right;">
-                    {{number_format_quantity($payment_order->total_payment)}}
-                </td>
-                <td></td>
-            </tr>
-            @endif
-            
-            <tr><td colspan="6"></td></tr>
-
-            <tr>
-                <td colspan="6" >
-                    <a href="{{ $url . '/formulir/'.$payment_order->formulir_id.'/approval/check-status/'.$token }}"><input
-                                type="button" class="btn btn-check" value="Check"></a>
-                    <a href="{{ $url . '/purchasing/point/service/payment-order/'.$payment_order->id.'/approve?token='.$token }}"><input
-                                type="button" class="btn btn-success" value="Approve"></a>
-                    <a href="{{ $url . '/purchasing/point/service/payment-order/'.$payment_order->id.'/reject?token='.$token }}"><input
-                                type="button" class="btn btn-danger" value="Reject"></a>
-                </td>
-            </tr>
         </table>
+
+        <div style="text-align: right;">
+            <h2> Payment Order Total: {{ number_format_quantity($payment_order->total_payment)}}</h2>
+            <a href="{{ $url . '/formulir/'.$payment_order->formulir_id.'/approval/check-status/'.$token }}"
+                class="btn btn-check"> Check </a>
+            <a href="{{ $url . '/purchasing/point/service/payment-order/'.$payment_order->id.'/approve?token='.$token }}"
+                class="btn btn-success"> Approve </a>
+            <a href="{{ $url . '/purchasing/point/service/payment-order/'.$payment_order->id.'/reject?token='.$token }}"
+                class="btn btn-danger"> Reject </a>
+         </div>
     @endforeach
-    @if($list_data->count() > 1)
-    <br>
-    <a href="{{ $url . '/purchasing/point/service/payment-order/approve-all/?formulir_id='.$array_formulir_id.'&token='.$token }}">
-        <input type="button" class="btn btn-primary" value="Approve All">
-    </a>
-    <a href="{{ $url . '/purchasing/point/service/payment-order/reject-all/?formulir_id='.$array_formulir_id.'&token='.$token }}">
-        <input type="button" class="btn btn-warning" value="Reject All">
-    </a>
+
+    @if(count($list_data) > 1)
+        <a href="{{ $url . '/purchasing/point/service/payment-order/approve-all/?formulir_id='.$array_formulir_id.'&token='.$token }}">
+            <input type="button" class="btn btn-primary" value="Approve All">
+        </a>
+        <a href="{{ $url . '/purchasing/point/service/payment-order/reject-all/?formulir_id='.$array_formulir_id.'&token='.$token }}">
+            <input type="button" class="btn btn-warning" value="Reject All">
+        </a>
     @endif
 </div>
 </body>


### PR DESCRIPTION
### Invoice
**Swap visibility of subtotal and tax base.**
Now subtotal will be visible if discount > 0 or tax > 0, and tax base will be visible only if type of tax is included.
**Hide discount column if no discount at all.**
Checks all items in the invoice, show discount column if at least 1 service or item that have discount.

[RESULT](https://mailtrap.io/api/v1/inboxes/384205/messages/846342000/body.html?api_token=7a24086af59317d821d07beab787a160)

### Payment Order
**Fix table layout to be more readable.**
Now the email also showing invoice detail with its discount and tax.
Added payment order notes in the header.

[RESULT](https://mailtrap.io/api/v1/inboxes/384205/messages/846703269/body.html?api_token=7a24086af59317d821d07beab787a160)
