### PR TITLE
fix form date in vesa dashboard

### DIFF
--- a/packages/point/point-manufacture/src/Vesa/InputVesa.php
+++ b/packages/point/point-manufacture/src/Vesa/InputVesa.php
@@ -29,7 +29,7 @@ trait InputVesa
         if ($merge_into_group && $list_input_in->count() > 5) {
             array_push($array, [
                 'url' => url('manufacture/point/process-io/vesa-approval'),
-                'deadline' => '', // $list_input_in->formulir->form_date,
+                'deadline' => $list_input_in->first()->formulir->form_date,
                 'message' => 'Please approve this manufacture process in number',
                 'permission_slug' => 'approval.point.manufacture.input'
             ]);
@@ -41,7 +41,7 @@ trait InputVesa
         foreach ($list_input_in->get() as $input_in) {
             array_push($array, [
                 'url' => url('manufacture/point/process-io/' . $input_in->id . '/input/' . $input_in->id),
-                'deadline' => '', // $input_in->formulir->form_date,
+                'deadline' => $input_in->formulir->form_date,
                 'message' => 'Please approve this manufacture process in number ' . $input_in->formulir->form_number,
                 'permission_slug' => 'approval.point.manufacture.input'
             ]);
@@ -58,11 +58,10 @@ trait InputVesa
         if ($merge_into_group && $list_manufacture->count() > 5) {
             array_push($array, [
                 'url' => url('manufacture/point/process-io/vesa-proses-after-approval'),
-                'deadline' => '',
-                'message' => 'Make an manufacture process out',
+                'deadline' => $list_manufacture->first()->formulir->form_date, // $list_manufacture->orderBy('form_date')->first()->form_date, not working
+                'message' => 'Make a manufacture process out',
                 'permission_slug' => 'create.point.manufacture.output'
             ]);
-
             return $array;
         }
 
@@ -71,7 +70,7 @@ trait InputVesa
             array_push($array, [
                 'url' => url('manufacture/point/process-io/' . $manufacture->id . '/output/create-step-2/' . $manufacture->id),
                 'deadline' => $manufacture->formulir->form_date,
-                'message' => 'Make an manufacture process out from ' . $manufacture->formulir->form_number,
+                'message' => 'Make a manufacture process out from ' . $manufacture->formulir->form_number,
                 'permission_slug' => 'create.point.manufacture.output'
             ]);
         }


### PR DESCRIPTION
Vesa manufacture tidak muncul di dashboard karena di app/index.blade.php ada ini

```
// VESA DUE DATE
$due_date = array_where($array_vesa, function ($value, $key) use ($array_vesa) {
    if (array_key_exists('due_date', $key)) {
        return $key['due_date'] == true;
    }
});

// VESA TODO
$todo = array_where($array_vesa, function ($value, $key) use ($array_vesa) {
    if (! array_key_exists('due_date', $key)) {
        return $key['deadline'] != '';
    } else {
        return $key['due_date'] == false;
    }
});
```

pengecekan deadline / due_date, dan di manufacture, deadline hanya dikosongi, jadi nggak masuk $todo atau $due_date, jadi nggak ditampilkan di dashboard